### PR TITLE
e2e: Fixing two failing conformance tests

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,10 +1,10 @@
-FROM bitnami/minideb:jessie
+FROM debian:stretch-20190204-slim
 LABEL "maintainer" "Andrew Kutz <akutz@vmware.com>"
 
 # Update the CA certificates and clean up the apt cache.
-RUN apt-get update && \
+RUN apt-get -y update && \
     apt-get -y --no-install-recommends install \
-    ca-certificates curl locales ruby tar unzip && \
+    ca-certificates curl locales python ruby tar unzip && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 # Set the locale so that the gist command is happy.
@@ -17,6 +17,7 @@ RUN gem install gist
 # Download the Google Cloud SDK
 RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-217.0.0-linux-x86_64.tar.gz | \
     tar xzC /
+RUN /google-cloud-sdk/bin/gcloud components update
 
 # Download Sonobuoy
 RUN curl -sSL https://github.com/heptio/sonobuoy/releases/download/v0.13.0/sonobuoy_0.13.0_linux_amd64.tar.gz | \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,32 +1,16 @@
 all: build
 
-E2E_IMAGE := gcr.io/kubernetes-conformance-testing/sk8e2e:latest
-
-DOCKER_BUILD := docker build
-ifeq (true,$(NOCACHE))
-DOCKER_BUILD += --no-cache
-endif
-DOCKER_BUILD += -t
-
+IMAGE := gcr.io/kubernetes-conformance-testing/sk8e2e:latest
 KEEPALIVE := hack/keepalive/keepalive.linux_amd64
+
 $(KEEPALIVE):
 	$(MAKE) -C hack/keepalive keepalive.linux_amd64
 
-.Dockerfile.built: 	Dockerfile \
-					*.tf vmc/*.tf \
-					cloud_config.yaml \
-					entrypoint.sh \
-					sonobuoy.yaml \
-					upload_e2e.py \
-					$(KEEPALIVE)
-	$(DOCKER_BUILD) $(E2E_IMAGE) . && touch "$@"
+build: image
+image: $(KEEPALIVE)
+	docker build -t $(IMAGE) .
 
-build: .Dockerfile.built
+push: image
+	docker push $(IMAGE)
 
-.Dockerfile.pushed: .Dockerfile.built
-	docker push $(E2E_IMAGE) && touch "$@"
-
-
-push: .Dockerfile.pushed
-
-.PHONY: build push
+.PHONY: build image push

--- a/e2e/hack/turn.sh
+++ b/e2e/hack/turn.sh
@@ -6,7 +6,7 @@ hackd=$(python -c "import os; print(os.path.realpath('$(dirname "${0}")'))")
 xdir="${hackd}/.."
 
 # Make sure the docker image is up to date.
-make -C "${xdir}" build
+#make -C "${xdir}" image
 
 # Build the docker run command line.
 drun="docker run -it --rm -v "${xdir}/data":/tf/data"
@@ -74,6 +74,9 @@ echo "${drun}"
 # Run docker.
 ${drun} \
   -e DEBUG="${DEBUG}" \
+  -e E2E_FOCUS="${E2E_FOCUS-}" \
+  -e E2E_SKIP="${E2E_SKIP-}" \
+  -e KUBE_CONFORMANCE_IMAGE="${KUBE_CONFORMANCE_IMAGE-}" \
   -e TF_VAR_ctl_count=${TF_VAR_ctl_count} \
   -e TF_VAR_bth_count=${TF_VAR_bth_count} \
   -e TF_VAR_wrk_count=${TF_VAR_wrk_count} \

--- a/e2e/sonobuoy.yaml
+++ b/e2e/sonobuoy.yaml
@@ -86,13 +86,15 @@ data:
     spec:
       env:
       - name: E2E_FOCUS
-        value: '\[Conformance\]'
+        value: '{{E2E_FOCUS}}'
       - name: E2E_SKIP
-        value: 'Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]'
+        value: '{{E2E_SKIP}}'
       - name: E2E_PARALLEL
         value: '1'
+      - name: E2E_PROVIDER
+        value: 'skeleton'
       command: ["/run_e2e.sh"]
-      image: gcr.io/heptio-images/kube-conformance:latest
+      image: {{KUBE_CONFORMANCE_IMAGE}}
       imagePullPolicy: Always
       name: e2e
       volumeMounts:


### PR DESCRIPTION
This patch is designed to fix the following e2e conformance tests:

1. #9 - `[sig-apps] Daemon set [Serial] [It] should rollback without unnecessary restarts [Conformance]`
2. #10 - `[sig-api-machinery] Aggregator [It] Should be able to support the 1.10 Sample API Server using the current Aggregator [Conformance]`

This patch does not fully address #10 as the root cause is not yet known. However, this patch does fix at least one issue with #10, hence its mention.

This patch *does* fix #9.