### PR TITLE
increase retry time to fix flakes

### DIFF
--- a/sk8.sh
+++ b/sk8.sh
@@ -391,7 +391,7 @@ CLEANUP_DISABLED=$(parse_bool "${CLEANUP_DISABLED}")
 CNI_BIN_DIR="${CNI_BIN_DIR:-/opt/bin/cni}"
 
 # The default curl command to use instead of invoking curl directly.
-CURL="curl --retry 5 --retry-delay 1 --retry-max-time 120"
+CURL="curl --retry 10 --retry-delay 1 --retry-max-time 300"
 
 # Setting CURL_DEBUG to a truthy value causes the default curl command
 # to use verbose mode. Please keep in mind that this can negatively


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

Today some of our prowjobs failed with the following 

```
could not stat https://github.com/containerd/containerd/releases/download/v1.1.7/containerd-1.1.7.linux-amd64.tar.gz
```

this increases retry-max-time and number of retries to make sure we have enough time

/assign @akutz 