### PR TITLE
deflake getting lease from etcd

### DIFF
--- a/e2e/input.tf
+++ b/e2e/input.tf
@@ -55,7 +55,7 @@ variable "os_seed_gid" {
 // If var.sk8 and var.sk8_file are not set then the script is fetched 
 // from the following URL.
 variable "sk8_url" {
-  default = "https://raw.githubusercontent.com/vmware/simple-k8s-test-env/master/sk8.sh"
+  default = "http://storage.googleapis.com/sk8-bin/sk8.sh"
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

/assign @akutz 

this fixes the following:

- getting the lease throwed some `Error: context deadline exceeded` now this adds retries for it
- move sk8.sh to GCS to avoid Github rate limiting

I'll rebuild the images (sk8 + ci) once this merges